### PR TITLE
Roi query

### DIFF
--- a/R/roi_query.r
+++ b/R/roi_query.r
@@ -108,7 +108,7 @@ setMethod("roi_query", "Catalog",
       r2    = query$r2[[1]]
       files = query$tiles[[1]]
       
-      lidar = readLAS(files) #,...
+      lidar = readLAS(files,...)
       output=vector("list", length(X))
       
       for(j in 1:length(X))


### PR DESCRIPTION
roi_query was assigning wrong roi names to output (roinames was assigned to output before aggregation by tiles of extraction which reorders the processing, instead of after). These modifications are fixing this issue assigning names of aggregated groups of queries in the first for loop (replaced by an lapply) and reordering to the original order at the end.