### PR TITLE
Fix: roi_index pb with one query, list() added for that case.

### DIFF
--- a/R/roi_index.r
+++ b/R/roi_index.r
@@ -79,7 +79,7 @@ setMethod("roi_index", "Catalog",
       dplyr::filter(coord.tiles, !(minx >= coord$maxx | maxx <= coord$minx | miny >= coord$maxy | maxy <= coord$miny))$tile
     })
 
-    coord.plot[, tiles := tiles]
+    coord.plot[, tiles := list(tiles)]
     coord.plot[, c("maxx", "maxy", "minx", "miny") := NULL]
 
     return(coord.plot[])


### PR DESCRIPTION
Fix: roi_index pb when only one query is asked, list() added for that case. Works with solo and multiple queries.