### PR TITLE
Some changes in lasnormalise

### DIFF
--- a/R/lasnormalize.r
+++ b/R/lasnormalize.r
@@ -62,7 +62,7 @@
 #' \link[raster:raster]{raster}
 #' \link[lidR:grid_terrain]{grid_terrain}
 #' @export
-lasnormalize = function(.las, dtm, na.rm=...)
+lasnormalize = function(.las, dtm, keep_Zdtm=FALSE, ...)
 {
   . <- Z <- Zn <- X <- Y <- NULL
 
@@ -80,6 +80,8 @@ lasnormalize = function(.las, dtm, na.rm=...)
     normalized@data$Zground=raster::extract(dtm, normalized@data[,.(X,Y)], ...)
 
     normalized@data[, Z := Z - Zdtm][]
+    if(!keep_Zdtm)
+      normalized@data[, Zdtm := NULL]
 
     gc()
 

--- a/R/lasnormalize.r
+++ b/R/lasnormalize.r
@@ -62,7 +62,7 @@
 #' \link[raster:raster]{raster}
 #' \link[lidR:grid_terrain]{grid_terrain}
 #' @export
-lasnormalize = function(.las, dtm, ...)
+lasnormalize = function(.las, dtm, na.rm=...)
 {
   . <- Z <- Zn <- X <- Y <- NULL
 
@@ -79,12 +79,7 @@ lasnormalize = function(.las, dtm, ...)
 
     normalized@data$Zground=raster::extract(dtm, normalized@data[,.(X,Y)], ...)
 
-    isna = is.na(normalized@data$Zn)
-
-  	if(sum(isna) > 0)
-	    warning(paste0(sum(isna), " points with NA elevation points found and removed."), call. = F)
-
-    normalized@data[, Z := Z - Zground][]
+    normalized@data[, Z := Z - Zdtm][]
 
     gc()
 

--- a/R/lasnormalize.r
+++ b/R/lasnormalize.r
@@ -77,7 +77,7 @@ lasnormalize = function(.las, dtm, keep_Zdtm=FALSE, ...)
   {
     normalized = LAS(data.table::copy(.las@data), .las@header)
 
-    normalized@data$Zground=raster::extract(dtm, normalized@data[,.(X,Y)], ...)
+    normalized@data$Zdtm=raster::extract(dtm, normalized@data[,.(X,Y)], ...)
 
     normalized@data[, Z := Z - Zdtm][]
     if(!keep_Zdtm)

--- a/R/lasnormalize.r
+++ b/R/lasnormalize.r
@@ -77,7 +77,7 @@ lasnormalize = function(.las, dtm, keep_Zdtm=FALSE, ...)
   {
     normalized = LAS(data.table::copy(.las@data), .las@header)
 
-    normalized@data$Zdtm=raster::extract(dtm, normalized@data[,.(X,Y)], ...)
+    normalized@data[, Zdtm := raster::extract(dtm, normalized@data[,.(X,Y)], ...)][]
 
     normalized@data[, Z := Z - Zdtm][]
     if(!keep_Zdtm)

--- a/R/lasnormalize.r
+++ b/R/lasnormalize.r
@@ -62,7 +62,7 @@
 #' \link[raster:raster]{raster}
 #' \link[lidR:grid_terrain]{grid_terrain}
 #' @export
-lasnormalize = function(.las, dtm)
+lasnormalize = function(.las, dtm, ...)
 {
   . <- Z <- Zn <- X <- Y <- NULL
 
@@ -77,15 +77,14 @@ lasnormalize = function(.las, dtm)
   {
     normalized = LAS(data.table::copy(.las@data), .las@header)
 
-    lasclassify(normalized, dtm, "Zn")
+    normalized@data$Zground=raster::extract(dtm, normalized@data[,.(X,Y)], ...)
 
     isna = is.na(normalized@data$Zn)
 
   	if(sum(isna) > 0)
 	    warning(paste0(sum(isna), " points with NA elevation points found and removed."), call. = F)
 
-    normalized@data[, Z := round(Z - Zn, 3)][, Zn := NULL][]
-    normalized = lasfilter(normalized, !isna)
+    normalized@data[, Z := Z - Zground][]
 
     gc()
 


### PR DESCRIPTION
This is more a draft suggestion than a real pull-request.
As I saw that you considered using a RasterLayer as dtm I think it is useless to pass through lasclassify.
Moreover, in raster::extract there are several ways to interpolate at coordinates (methods, function over buffered points), it would be better if kept available to user in my opinion. I did it in lasnormalise but it could also be done in lasclassify.
A third thing was to have the possibility to keep Zdtm, as it can serve in the following.
Finally, in my opinion NA shouldn't be removed by other than user. I thought of a na.rm argument, but this argument is already being used by raster::extract. Thus I think NA points should be left and filtered by user afterwards.

If you feel some of these suggestions would be good I'll make a real pull-request