### PR TITLE
Gap fraction profile

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: Airborne LiDAR Data Manipulation and Visualization for Forestry
     Applications
 Version: 1.1.0
-Date: 2016-12-31
+Date: 2017-02-05
 Authors@R: c(
     person("Jean-Romain", "Roussel", email = "jean-romain.roussel.1@ulaval.ca", role = c("aut", "cre", "cph")),
     person("David", "Auty", email = "", role = c("aut", "ctb"), comment = "Reviews the documentation"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Imports:
 Suggests:
     rgdal,akima,gstat,sp,testthat,EBImage
 LazyData: true
-RoxygenNote: 6.0.0
+RoxygenNote: 6.0.1
 LinkingTo: Rcpp
 Encoding: UTF-8
 biocViews: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+### FIXE
+* [#48](https://github.com/Jean-Romain/lidR/pull/48) `gap_fraction_profile()` bug with negative values (thanks to Florian de Boissieu)
+
 ### lidR v1.1.0 (Release date: 2017-02-05)
 
 #### NEW

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * internally `lascheck` perform more tests to check if the header is in accordance with the data.
 
-### BUG FIXES
+#### BUG FIXES
 
 * [#48](https://github.com/Jean-Romain/lidR/pull/48) `gap_fraction_profile()` bug with negative values (thanks to Florian de Boissieu)
 

--- a/R/metrics.r
+++ b/R/metrics.r
@@ -156,7 +156,7 @@ stdmetrics = function(x, y, z, i, a, rn, class, pulseID, dz = 1)
 gap_fraction_profile = function (z, dz = 1, z0 = 2)
 {
 
-  bk = seq(floor((min(z)-z0)/dz)*dz+z0, ceiling((maxz-z0)/dz)*dz+z0, dz)
+  bk = seq(floor((min(z)-z0)/dz)*dz+z0, ceiling((max(z)-z0)/dz)*dz+z0, dz)
 
   histogram = graphics::hist(z, breaks = bk, plot = F)
   h = histogram$mids
@@ -173,7 +173,7 @@ gap_fraction_profile = function (z, dz = 1, z0 = 2)
   z = h[-1]
   i = i[-c(1, length(i))]
 
-  return(data.frame(z[z>z0], gf = i[z>z0])
+  return(data.frame(z[z>z0], gf = i[z>z0]))
 }
 
 #' Leaf area density
@@ -203,7 +203,7 @@ gap_fraction_profile = function (z, dz = 1, z0 = 2)
 #' @export LAD
 LAD = function(z, dz = 1, k = 0.5, z0 = 2) # (Bouvier et al. 2015)
 {
-	ld = gap_fraction_profile(z, dz)
+	ld = gap_fraction_profile(z, dz, z0)
 
 	if(anyNA(ld))
 	  return(NA_real_)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](https://raw.githubusercontent.com/Jean-Romain/lidR/gh-pages/images/lidr-ban.png)<br/>
 
-![CRAN](https://img.shields.io/badge/CRAN-1.0.2-brightgreen.svg)  ![Github](https://img.shields.io/badge/Github-1.1.0-green.svg) ![licence](https://img.shields.io/badge/Licence-GPL--3-blue.svg)
+![CRAN](https://img.shields.io/badge/CRAN-1.1.0-brightgreen.svg)  ![Github](https://img.shields.io/badge/Github-1.1.0-green.svg) ![licence](https://img.shields.io/badge/Licence-GPL--3-blue.svg)
 
 R package for Airborne LiDAR Data Manipulation and Visualization for Forestry Applications
 

--- a/man/LAD.Rd
+++ b/man/LAD.Rd
@@ -4,7 +4,7 @@
 \alias{LAD}
 \title{Leaf area density}
 \usage{
-LAD(z, dz = 1, k = 0.5)
+LAD(z, dz = 1, k = 0.5, z0 = 2)
 }
 \arguments{
 \item{z}{vector of positive z coordinates}
@@ -12,6 +12,8 @@ LAD(z, dz = 1, k = 0.5)
 \item{dz}{numeric. The thickness of the layers used (height bin)}
 
 \item{k}{numeric. is the extinction coefficient}
+
+\item{z0}{numeric. The bottom limit of the profile}
 }
 \value{
 A data.frame containing the bin elevations (z) and leaf area density for each bin (lad)

--- a/man/gap_fraction_profile.Rd
+++ b/man/gap_fraction_profile.Rd
@@ -4,12 +4,14 @@
 \alias{gap_fraction_profile}
 \title{Gap fraction profile}
 \usage{
-gap_fraction_profile(z, dz = 1)
+gap_fraction_profile(z, dz = 1, z0 = 2)
 }
 \arguments{
 \item{z}{vector of positive z coordinates}
 
 \item{dz}{numeric. The thickness of the layers used (height bin)}
+
+\item{z0}{numeric. The bottom limit of the profile}
 }
 \value{
 A data.frame containing the bin elevations (z) and the gap fraction for each bin (gf)


### PR DESCRIPTION
fix: gap fraction and LAD were returning an error with points under 0
fix: LAD is defined as -log(gap_fraction)/(k*dz) (Bouvier et al. 2015)
add: option z0 to gap_fraction_profile and LAD to choose from where to start the profile