### PR TITLE
Changes to satisfy clang++ compiler

### DIFF
--- a/src/BoundingBox.h
+++ b/src/BoundingBox.h
@@ -14,3 +14,4 @@ struct BoundingBox
 };
 
 #endif //BBOX_H
+

--- a/src/Point.h
+++ b/src/Point.h
@@ -41,3 +41,4 @@ private:
 };
 
 #endif //POINT_H
+

--- a/src/QuadTree.h
+++ b/src/QuadTree.h
@@ -44,3 +44,4 @@ class QuadTree
 };
 
 #endif //QT_H
+

--- a/src/algo_li2012.cpp
+++ b/src/algo_li2012.cpp
@@ -54,7 +54,8 @@ IntegerVector algo_li2012(S4 las, double dt1, double dt2, double th_tree, double
    * INITALISATION STUFF *
    ***********************/
 
-  DataFrame data = las.slot("data");
+  // DataFrame data = las.slot("data");
+  DataFrame data = as<Rcpp::DataFrame>(las.slot("data"));
 
   NumericVector X = data["X"];
   NumericVector Y = data["Y"];

--- a/src/grid_generic.cpp
+++ b/src/grid_generic.cpp
@@ -34,7 +34,8 @@ List Cpp_grid_canopy(S4 las, double res, double subcircle = 0)
 {
   S4 header = las.slot("header");
   List phb  = header.slot("PHB");
-  DataFrame data = las.slot("data");
+  // DataFrame data = las.slot("data");
+  DataFrame data = as<Rcpp::DataFrame>(las.slot("data"));
 
   double xmax = phb["Max X"];
   double xmin = phb["Min X"];
@@ -83,3 +84,4 @@ List Cpp_grid_canopy(S4 las, double res, double subcircle = 0)
     return(List(0));
   }
 }
+

--- a/src/local_maxima.cpp
+++ b/src/local_maxima.cpp
@@ -82,7 +82,8 @@ IntegerMatrix C_LocalMaximaMatrix(NumericMatrix image, int ws, double th)
 // [[Rcpp::export]]
 LogicalVector C_LocalMaximaPoints(S4 las, double ws, double min_height, bool displaybar = false)
 {
-  DataFrame data = las.slot("data");
+  // DataFrame data = las.slot("data");
+  DataFrame data = as<Rcpp::DataFrame>(las.slot("data"));
 
   NumericVector X = data["X"];
   NumericVector Y = data["Y"];
@@ -149,3 +150,4 @@ LogicalVector C_LocalMaximaPoints(S4 las, double ws, double min_height, bool dis
 
   return is_maxima;
 }
+


### PR DESCRIPTION
Fixes the following various ambiguous type errors generated by clang++ (3.9.1) on mac:

```
algo_li2012.cpp:57:13: error: conversion from                                                  
      'Rcpp::SlotProxyPolicy<Rcpp::S4_Impl<PreserveStorage> >::SlotProxy' to 'DataFrame' (aka  
      'DataFrame_Impl<PreserveStorage>') is ambiguous                                          
  DataFrame data = las.slot("data");                                                           
            ^      ~~~~~~~~~~~~~~~~                                                            
/Library/Frameworks/R.framework/Versions/3.4/Resources/library/Rcpp/include/Rcpp/proxy/SlotProx
y.h:42:31: note:                                                                               
      candidate function [with T = Rcpp::DataFrame_Impl<PreserveStorage>]                      
        template <typename T> operator T() const;                                              
                              ^                                                                
/Library/Frameworks/R.framework/Versions/3.4/Resources/library/Rcpp/include/Rcpp/DataFrame.h:51
:9: note:                                                                                      
      candidate constructor [with T = Rcpp::SlotProxyPolicy<Rcpp::S4_Impl<PreserveStorage>     
      >::SlotProxy]                                                                            
        DataFrame_Impl( const T& obj ) ;  
```

Slight changes to remove `-Wnewline-eof warnings! `