### PR TITLE
Update function 'entropy' in 'metrics.R'

### DIFF
--- a/R/metrics.r
+++ b/R/metrics.r
@@ -275,7 +275,7 @@ entropy = function(z, by = 1, zmax = NULL)
     stop("Entropy found negatives values. Returned NA.")
 
 	# Define the x meters bins from 0 to zmax (rounded to the next integer)
-	bk = seq(0, ceiling(zmax), by)
+	bk = seq(0, ceiling(zmax/by)*by, by)
 
 	# Compute the p for each bin
 	hist = findInterval(z, bk)


### PR DESCRIPTION
breaks calculation in the function 'entropy' has the potential to exclude points when supplied bin-width argument is greater than 1. For example when zmax = 20.38 and by = 5 the last break point will be 20 and the maximum point will be excluded, returning an error. The proposed change uses the same method as implemented for a similar calculation in the function 'gap_fraction_profile'.