### PR TITLE
Fix bug introduced into cluster_apply

### DIFF
--- a/R/clusters_apply.r
+++ b/R/clusters_apply.r
@@ -10,7 +10,7 @@ cluster_apply = function(clusters, f, ncores, progress, stop_early, ...)
   future::plan(future::multiprocess, workers = ncores)
 
   # User supplied function not being analysed for globals/packages by the future we have to do it manually.
-  if (ncores > 1 && !future::supportsMulticore())
+  if (ncores > 1)
   {
     dots <- list(...)
     is.fun <- vapply(dots, is.function, logical(1))


### PR DESCRIPTION
Tests of the latest version of catalog_apply/cluster_apply on a more complicated function did not adequately capture all of the required packages. The code I wrote additionally fails when the name attribute of each element of `where` returns `NULL`, as `vapply` expects a length one character vector. 

It may also be worthwhile adding the condition that these checks are only run when the machine does not support multicore processing, i.e. changing the condition to `ncores > 1 && !future::supportsMulticore()`, so that non-windows users aren't unnecessarily impacted by these checks. I haven't added this code into the pull request as I can't test what this inclusion would do outside of a windows environment (I've broken enough code for one day).