### PR TITLE
bug in treetops ID check

### DIFF
--- a/R/lastrees_dalponte.r
+++ b/R/lastrees_dalponte.r
@@ -82,7 +82,7 @@ lastrees_dalponte = function(las, chm, treetops, th_tree = 2, th_seed = 0.45, th
     if (all(is.na(cells)))
       stop("No seed found", call. = FALSE)
     else
-      stop("Some seeds are outside the canopy height model.", call. = FALSE)
+      warning("Seeds outside the canopy height model are removed.", call. = FALSE)
 
     treetops_df = treetops_df[!is.na(cells),]
     cells = cells[!is.na(cells)]

--- a/man/lastrees_dalponte.Rd
+++ b/man/lastrees_dalponte.Rd
@@ -15,7 +15,7 @@ automatically.}
 or \link[lidR:grid_tincanopy]{grid_tincanopy} or read it from an external file.}
 
 \item{treetops}{\code{RasterLayer} or \code{data.frame} containing the position of the
-trees. Can be computed with \link[lidR:tree_detection]{tree_detection} or read from an external file.}
+tree tops, with X and Y as first and the second column respectively. Can be computed with \link[lidR:tree_detection]{tree_detection} or read from an external file.}
 
 \item{th_tree}{numeric. Threshold below which a pixel cannot be a tree. Default 2.}
 


### PR DESCRIPTION
There was a bug on treetop ID.
However, it raises a question about the expected third column, which seems to be an ID and not a Z value as it is given by tree_detection. Thus if several tree tops have the exact same height, the algorithm throws an error. And if several tops have the same integer part they will be identified with the same color. Thus
Thus, to make it work properly without the user-defined ID option (like in the other algorithms):
- I replaced treetops_df[, 3] by  treetops_df[[3]]
- I changed to generate a unique treetops_df integer ID systematically
If the possibility to have a user-defined treetop ID is wanted, it could be either given in a new argument or expressed specifically to be the third column or the RasterLayer value in the manual. In that case, this option should be thought for the other algorithms as well, to be homogeneous and to keep lastrees working, shouldn't it?