### PR TITLE
fix typo in normalization

### DIFF
--- a/src/C_knn.cpp
+++ b/src/C_knn.cpp
@@ -70,7 +70,7 @@ NumericVector C_knnidw(NumericVector X, NumericVector Y, NumericVector Z, Numeri
 
   QuadTree tree(X,Y);
 
-  Progress pbar(n, "Inveert distance weigthning: ");
+  Progress pbar(n, "Inverse distance weighting: ");
 
   for(unsigned int i = 0 ; i < n ; i++)
   {


### PR DESCRIPTION
The progress par in lasnormalize read "Inveert distance weigthning" changed to "Inverse distance weighting"