### PR TITLE
use sf::st_geometry() to get geometry column from sf object

### DIFF
--- a/R/clip_roi.R
+++ b/R/clip_roi.R
@@ -385,7 +385,7 @@ clip_sf = function(las, sf)
 
 clip_sf.LAS = function(las, sf)
 {
-  wkt <- sf::st_as_text(sf$geometry, digits = 10)
+  wkt <- sf::st_as_text(sf::st_geometry(sf), digits = 10)
 
   output = vector(mode = "list", length(wkt))
   for (i in 1:length(wkt))
@@ -405,7 +405,7 @@ clip_sf.LAS = function(las, sf)
 
 clip_sf.LAScatalog = function(las, sf)
 {
-  wkt  <- sf::st_as_text(sf$geometry, digits = 10)
+  wkt  <- sf::st_as_text(sf::st_geometry(sf), digits = 10)
 
   bboxes <- lapply(wkt, function(string)
   {
@@ -465,7 +465,7 @@ catalog_extract = function(ctg, bboxes, shape = LIDRRECTANGLE, sf = NULL, data =
 
     # If a simple feature is provided we want to extract a polygon. Insert WKT string
     if (!is.null(sf))
-      clusters[[i]]@wkt = sf::st_as_text(sf$geometry[i], digits = 10)
+      clusters[[i]]@wkt = sf::st_as_text(sf::st_geometry(sf)[i], digits = 10)
 
     # If the user wants to write the ROIs in files. Generate a filename.
     if (opt_output_files(ctg) != "")


### PR DESCRIPTION
using the st_geometry() function instead of $geometry ensures that the clipping functions work when the geometry column is named something other than "geometry"

See Issue 333: [https://github.com/Jean-Romain/lidR/issues/333](https://github.com/Jean-Romain/lidR/issues/333)