### PR TITLE
fixes bug where simple features with geometry column not named...

### DIFF
--- a/R/lasclip.r
+++ b/R/lasclip.r
@@ -332,7 +332,7 @@ lasclipSimpleFeature = function(las, sf)
 
 lasclipSimpleFeature.LAS = function(las, sf)
 {
-  wkt <- sf::st_as_text(sf$geometry, digits = 10)
+  wkt <- sf::st_as_text(sf::st_geometry(sf), digits = 10)
 
   output = vector(mode = "list", length(wkt))
   for (i in 1:length(wkt))
@@ -352,7 +352,7 @@ lasclipSimpleFeature.LAS = function(las, sf)
 
 lasclipSimpleFeature.LAScatalog = function(las, sf)
 {
-  wkt  <- sf::st_as_text(sf$geometry, digits = 10)
+  wkt  <- sf::st_as_text(sf::st_geometry(sf), digits = 10)
 
   bboxes <- lapply(wkt, function(string)
   {
@@ -408,7 +408,7 @@ catalog_extract = function(ctg, bboxes, shape = LIDRRECTANGLE, sf = NULL, data =
 
     # If a simple feature is provided we want to extract a polygon. Insert WKT string
     if (!is.null(sf))
-      clusters[[i]]@wkt = sf::st_as_text(sf$geometry[i], digits = 10)
+      clusters[[i]]@wkt = sf::st_as_text(sf::st_geometry(sf)[i], digits = 10)
 
     # If the user wants to write the ROIs in files. Generate a filename.
     if (opt_output_files(ctg) != "")


### PR DESCRIPTION
..."geometry" would throw an error

Using sf::st_geometry() to access the geometry column of a simple feature ensures the geometry column (whatever it may be called) is used to get the geometry. If $geometry is used and the geometry column is called something different (e.g., lots of real-world instances where geometry column is called "geom") then NULL results, and sf::st_as_text() throws an error.