### PR TITLE
typo that prevents install

### DIFF
--- a/man/LAScatalog-class.Rd
+++ b/man/LAScatalog-class.Rd
@@ -113,7 +113,7 @@ allowed templates is described in the documentation for each function. See \link
 \item \strong{drivers}: list. This contains all the drivers required to seamlessly write Raster*,
 Spatial*, LAS objects. It is recommended that only advanced users change this option. A dedicated
 page describes the drivers in \link{lidR-LAScatalog-drivers}.
-\iten \strong{merge}: boolean. Multiple objects are merged into a single one at the end of the processing.
+\item \strong{merge}: boolean. Multiple objects are merged into a single one at the end of the processing.
 }
 }
 


### PR DESCRIPTION
\item instead of \iten, which causes an error upon install with {remotes}

```
remotes::install_github("Jean-Romain/lidR@devel")

...
Error : (converted from warning) /private/var/folders/xl/hy7rwmvx4llff5_00gwbk2vh0000gp/T/RtmpfKPFkY/R.INSTALLe5de7a1086de/lidR/man/LAScatalog-class.Rd:116: unknown macro '\iten'
ERROR: installing Rd objects failed for package ‘lidR’

...
```