### PR TITLE
test CRS equivalence not equality

### DIFF
--- a/tests/testthat/test-projection.R
+++ b/tests/testthat/test-projection.R
@@ -8,7 +8,12 @@ test_that("Internal projection conversion works", {
   expected <- sp::CRS("+init=epsg:2008")
   expected@projargs <- sub("\\+init=epsg:\\d+\\s", "", expected@projargs)
 
-  expect_equal(lidR:::epsg2CRS(2008), expected)
+  if (rgdal::new_proj_and_gdal()) {
+    expect_true(rgdal::compare_CRS(lidR:::epsg2CRS(2008),
+      expected)["equivalent"])
+  } else {
+    expect_equal(lidR:::epsg2CRS(2008), expected)
+  }
   expect_equal(lidR:::epsg2CRS(200800), sp::CRS())
   expect_error(lidR:::epsg2CRS(200800, fail = TRUE), "Invalid epsg code")
 


### PR DESCRIPTION
In preparing for new **sp** and **rgdal** releases, I've been trying to send the SRS_string to PROJ directly, not going through GDAL to PROJ. This leads to minor differences between `sp::CRS("+init=epsg:2008")` and `sp::CRS(SRS_string="EPSG:2008")`. The WKT2 strings are equivalent but not strictly identical; the former has:
```
    CS[Cartesian,2],
        AXIS["(E)",east,
            ORDER[1],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
        AXIS["(N)",north,
            ORDER[2],
            LENGTHUNIT["metre",1,
                ID["EPSG",9001]]],
    USAGE[
        SCOPE["unknown"],
        AREA["Canada - Quebec - east of 57°W"],
        BBOX[46.6,-57,53.76,-54]]] 
```
while the latter drops two `ID[]` authority declarations and adds one:
```
    CS[Cartesian,2],
        AXIS["easting (X)",east,
            ORDER[1],
            LENGTHUNIT["metre",1]],
        AXIS["northing (Y)",north,
            ORDER[2],
            LENGTHUNIT["metre",1]],
    USAGE[
        SCOPE["unknown"],
        AREA["Canada - Quebec - east of 57°W"],
        BBOX[46.6,-57,53.76,-54]],
    ID["EPSG",2008]] 
```
The differences are picked up by `expect_equal()`, but are not real differences. Using `rgdal::compare_CRS()` gives equivalence, that is the same underlying CRS but differing in unimportant textual representation. I haven't checked for **roxygen2** imports, but because **rgdal** is imported anyway, the substitution works. I also haven't checked with PROJ < 6 and GDAL < 3.