### PR TITLE
Include ENL function to Update utils_metrics.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ Authors@R: c(
     person("Andrew", "Sánchez Meador", email = "", role = ("ctb"), comment = "Implemented wing2015() for segment_snags()"),
     person("Bourdon", "Jean-François", email = "", role = ("ctb"), comment = "Contributed to Roussel2020() for track_sensor()"),
     person("Gatziolis", "Demetrios", email = "", role = ("ctb"), comment = "Implemented Gatziolis2019() for track_sensor()"))
+    person("Leonard", "Hambrecht", email = "", role = ("ctb"), comment = "Implemented ENL"))
 Description: Airborne LiDAR (Light Detection and Ranging) interface for data
     manipulation and visualization. Read/write 'las' and 'laz' files, computation
     of metrics in area based approach, point filtering, artificial point reduction,


### PR DESCRIPTION
Added function to calculate Effective Number of Layers (ENL) based on the method by Ehbrecht et al. 2016. ENL included Hill number 0D, 1D, 2D. 1D is based on the Shannon diversity index while 2D is based on the Simpson diversity index. 
Empty layers are not removed which will lead to empty cells when 1D is calculated with `grid_metrics`.

ALS and space-borne LiDAR papers often use the foliage height diversity [FHD] (based on Shannon diversity index) to assess the vertical forest structure. However, because Shannon diversity indices rely on the natural log it can not deal with empty layers. This is a really issue for high point density point clouds such as from UAV based LiDAR, dens forest due to occlusion and forest with gaps in the vertical structure.
Ehbrecht et al. proposed the ENL based on TLS scan but can be applied to ALS as well. ENL is more intuitive then FHD which is a common criticism. Furthermore, 2D ENL is based on the Simpson diversity index which is not based on the natural log and therefore can deal with empty layers. This makes it more suitable for high point density. The scalability of ENL is currently being explored but first impression seem to be promising to be able to scale ENL from TLS to ALS and even space-borne lidar.

Code needs to be reviewed but I try to based it on the entropy function.