### PR TITLE
Fix error during parallelization with multisession plan

### DIFF
--- a/R/utils_threads.R
+++ b/R/utils_threads.R
@@ -91,7 +91,7 @@ get_future_workers = function()
 
     if (is.call(n))               # e.g. plan(multisession or plan(cluster)
     {
-      n <- eval(n)
+      n <- eval(n, envir = environment(parallelly::availableCores))
       if (is.numeric(n))
         return(n)
       else
@@ -108,7 +108,7 @@ get_future_workers = function()
 
     if (is.call(n))               # e.g. plan(multisession) or plan(cluster)
     {
-       n <- eval(n)
+       n <- eval(n, envir = environment(parallelly::availableCores))
        if (is.numeric(n))
          return(n)
        else
@@ -142,7 +142,7 @@ must_disable_openmp = function()
 
   workers    <- getWorkers()
   threads    <- getThreads()
-  cores      <- future::availableCores()
+  cores      <- parallelly::availableCores()
 
   if (is.null(workers))
   {


### PR DESCRIPTION
Dear JRR,

when I switched my lidR version from 3.1.1 to  3.1.2, some of my code which called `catalog_apply` threw an error that went something like "Error in availableWorkers() : could not find function "availableWorkers"".

I was using `future::plan(future::multisession)` on Kubuntu 18.04.

I tracked the error to the [`get_future_workers` function](https://github.com/Jean-Romain/lidR/blob/f989b8a1bc1f070529004226cdb9391833c170ff/R/utils_threads.R#L63). There, the current `future` strategy is fetched by a call to `future::plan()`. The returned strategy object seems to be a function and has an argument called "workers" which is extracted inside of `get_future_workers`. Depending on the strategy, the extracted argument can contain a call to `availableWorkers()` (and I think it can also be a call to `availableCores()`). When this call is evaluated later on in the function, it throws the above mentioned error.

I fixed the error by evaluating the call in the environment of the `availableCores` function which is part of the `parallelly` package [since version 1.20.0 from 2020-10-30](https://github.com/HenrikBengtsson/future/blob/20d5247f75272528304bc6260fc7be609f25d8cf/NEWS#L155).

I know nearly nothing about environments! So I'm really unsure whether this is the way to go about this. The call to `environment(parallelly::availableCores)` returns `<environment: namespace:parallelly>` in the R console so it looks like it's just the environment of the parallelly package which is what we want there?

Currently, this fix works for me, but it definitely has to be tested on clusters and other environments.

Cheers,
Leon