### PR TITLE
Accommodate R-devel changes

### DIFF
--- a/src/altrep.cpp
+++ b/src/altrep.cpp
@@ -16,6 +16,7 @@ bool is_materialized(SEXP x)
 // [[Rcpp::export]]
 SEXP altrep_full_class(SEXP x) {
   if (!ALTREP(x)) return R_NilValue;
+#if R_VERSION >= R_Version(4, 6, 0)
   std::vector<std::string> v;
   auto visitor = [](SEXP name, SEXP attr, void* data) -> SEXP {
     std::vector<std::string>* ptr = static_cast<std::vector<std::string>*>(data);
@@ -25,4 +26,7 @@ SEXP altrep_full_class(SEXP x) {
   };
   R_mapAttrib(ALTREP_CLASS(x), visitor, static_cast<void*>(&v));
   return Rcpp::wrap(v);
+#else
+  return ATTRIB(ALTREP_CLASS(x));
+#fi
 }

--- a/src/altrep.cpp
+++ b/src/altrep.cpp
@@ -15,7 +15,14 @@ bool is_materialized(SEXP x)
 
 // [[Rcpp::export]]
 SEXP altrep_full_class(SEXP x) {
-  if (ALTREP(x)) return ATTRIB(ALTREP_CLASS(x));
-  return R_NilValue;
+  if (!ALTREP(x)) return R_NilValue;
+  std::vector<std::string> v;
+  auto visitor = [](SEXP name, SEXP attr, void* data) -> SEXP {
+    std::vector<std::string>* ptr = static_cast<std::vector<std::string>*>(data);
+    std::string s{CHAR(Rf_asChar(attr))};
+    ptr->push_back(s);
+    return NULL;
+  };
+  R_mapAttrib(ALTREP_CLASS(x), visitor, static_cast<void*>(&v));
+  return Rcpp::wrap(v);
 }
-

--- a/src/knn.cpp
+++ b/src/knn.cpp
@@ -93,7 +93,7 @@ List cpp_knnx(S4 data, S4 query, int k, int ncpu)
   NumericVector Z = tmp["Z"];
 
   int npoints = X.size();
-  k = std::min(k, temp.nrow());
+  k = std::min(static_cast<R_xlen_t>(k), temp.nrow());
 
   IntegerMatrix knn_idx(npoints, k);
   NumericMatrix knn_dist(npoints, k);

--- a/src/knn.cpp
+++ b/src/knn.cpp
@@ -93,7 +93,7 @@ List cpp_knnx(S4 data, S4 query, int k, int ncpu)
   NumericVector Z = tmp["Z"];
 
   int npoints = X.size();
-  k = std::min(static_cast<R_xlen_t>(k), temp.nrow());
+  k = std::min(k, static_cast<int>(temp.nrow());
 
   IntegerMatrix knn_idx(npoints, k);
   NumericMatrix knn_dist(npoints, k);


### PR DESCRIPTION
Salut @Jean-Romain,

As discussed the other day over in lasR repo in this org, Luke Tierney is tightening the R API.  In R's move away from ATTRIB() we changed how we compute the number of rows in a data.frame (it is easier and better now) but also changed to returning a larger R_xlen_t.  It turns out your file src/knn.cpp is the only one using this in a type-checking context such as the `std::min()` so it needs a cast.   

When looking at this I noticed CRAN is also nagging you about ATTRIB so I injected a C++ alternative with a 'visitor' passed to the (allowed, added in R 4.6.0 aka R-devel) R_mapAttrib.  With both these changes, the packages passes all checks under R-devel.

There are two small things remaining.  Kurt added more URL checks, so your manual pages complain:

```
* checking CRAN incoming feasibility ... [2s/12s] NOTE          
Maintainer: ‘Jean-Romain Roussel <info@r-lidar.com>’
                                                    
Found the following (possibly) invalid URLs:   
  URL: https://www.asprs.org/divisions-committees/lidar-division/laser-las-file-format-exchange-activities
    From: man/add_attribute.Rd          
          man/classify.Rd                                                                                
          man/las_utilities.Rd
          man/LAS-class.Rd   
          man/LASheader-class.Rd
          man/rasterize.Rd
    Status: 404
    Message: Not Found
* checking package namespace information ... OK
```

That should be easy to fix.  More annoyingly, Luke has one more for you on 

```
* checking compiled code ... NOTE
File ‘lidR/libs/lidR.so’:
  Found non-API call to R: ‘SETLENGTH’

Compiled code should not call non-API entry points in R.

See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual,
and section ‘Moving into C API compliance’ for issues with the use of
non-API entry points.
* checking installed files from ‘inst/doc’ ... OK
```

There is an entire new section [Resizing Vectors](https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Resizing-vectors) in WRE that I can point you too, but I didn't want to make invasive changes. It seems like if you declare a vector 'resizable' on allocation you are allowed to shrink it.

Hope this helps, and once again thanks for considering these changes.  Happy Holidays, and a Happy 2026!
